### PR TITLE
Removed references to pry.

### DIFF
--- a/natero/lib/natero.rb
+++ b/natero/lib/natero.rb
@@ -1,6 +1,5 @@
 require 'httparty'
 require 'json'
-require 'pry'
 
 module Natero
   class Configuration

--- a/natero/natero.gemspec
+++ b/natero/natero.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |spec|
   spec.files         = `git ls-files -z`.split("\x0").reject { |f| f.match(%r{^(test|spec|features)/}) }
   spec.bindir        = 'exe'
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
-  spec.require_paths = 'lib'
+  spec.require_paths = ['lib']
 
   spec.add_dependency 'httparty', '~> 0.13'
   spec.add_development_dependency 'bundler', '~> 1.11'

--- a/natero/natero.gemspec
+++ b/natero/natero.gemspec
@@ -2,7 +2,6 @@
 lib = File.expand_path('../lib', __FILE__)
 $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 require 'natero/version'
-require 'pry'
 
 Gem::Specification.new do |spec|
   spec.name          = 'natero'


### PR DESCRIPTION
Hey @markovAntony, 

This PR removes references to `pry`, as it should not be part of the gem's code. A development dependency can be added for it, but production code should not include this gem anyway, so the requires shouldn't be in place. 

Please check it out, thanks! 