### PR TITLE
Use array, fails on older Ruby versions

### DIFF
--- a/natero/natero.gemspec
+++ b/natero/natero.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |spec|
   spec.files         = `git ls-files -z`.split("\x0").reject { |f| f.match(%r{^(test|spec|features)/}) }
   spec.bindir        = 'exe'
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
-  spec.require_paths = 'lib'
+  spec.require_paths = ['lib']
 
   spec.add_dependency 'httparty', '~> 0.13'
   spec.add_development_dependency 'bundler', '~> 1.11'


### PR DESCRIPTION
Hey @markovAntony, 

This PR fixes the gem to work on Ruby 2.1, it only seems to be working for >= Ruby 2.2.

Please check it out, thanks! 