### PR TITLE
Avoid "no implicit conversion" error

### DIFF
--- a/lib/natero/base.rb
+++ b/lib/natero/base.rb
@@ -1,3 +1,6 @@
+require 'active_support'
+require 'active_support/core_ext'
+
 class Natero::Base
   include Serializable
 

--- a/lib/natero/request_helper.rb
+++ b/lib/natero/request_helper.rb
@@ -1,23 +1,23 @@
 require 'httparty'
 
 class Natero::RequestHelper
-  def get(path_params=[], data=nil)
+  def get(path_params=[], data={})
     request(:get, path_params, data)
   end
 
-  def post(path_params=[], data=nil)
+  def post(path_params=[], data={})
     request(:post, path_params, data)
   end
 
-  def put(path_params=[], data=nil)
+  def put(path_params=[], data={})
     request(:put, path_params, data)
   end
 
-  def delete(path_params=[], data=nil)
+  def delete(path_params=[], data={})
     request(:delete, path_params, data)
   end
 
-  def request(method, path_params=[], data=nil)
+  def request(method, path_params=[], data={})
     parse_response(HTTParty.send(method, @model.endpoint(path_params), data))
   end
 


### PR DESCRIPTION
This PR fixes TypeError while requesting to `/accounts` endpoint.

```
Natero.configuration.account_api_key = 'YOUR-ACCOUNT-API-KEY'
Natero::Account.retrieve_all
Traceback (most recent call last):
       10: from bin/console:14:in `<main>'
        9: from (irb):2
        8: from /Users/kakipo/work/natero/lib/natero/account.rb:3:in `retrieve_all'
        7: from /Users/kakipo/work/natero/lib/natero/base.rb:15:in `get'
        6: from /Users/kakipo/work/natero/lib/natero/request_helper.rb:5:in `get'
        5: from /Users/kakipo/work/natero/lib/natero/request_helper.rb:21:in `request'
        4: from /Users/kakipo/.rbenv/versions/2.5.1/lib/ruby/gems/2.5.0/gems/httparty-0.16.2/lib/httparty.rb:601:in `get'
        3: from /Users/kakipo/.rbenv/versions/2.5.1/lib/ruby/gems/2.5.0/gems/httparty-0.16.2/lib/httparty.rb:489:in `get'
        2: from /Users/kakipo/.rbenv/versions/2.5.1/lib/ruby/gems/2.5.0/gems/httparty-0.16.2/lib/httparty.rb:560:in `perform_request'
        1: from /Users/kakipo/.rbenv/versions/2.5.1/lib/ruby/gems/2.5.0/gems/httparty-0.16.2/lib/httparty.rb:560:in `merge'
TypeError (no implicit conversion of nil into Hash)
```